### PR TITLE
Optimization for OrDocIdSet, AndDocIdSet, etc

### DIFF
--- a/src/main/java/com/kamikaze/docidset/impl/ImmutableDocSet.java
+++ b/src/main/java/com/kamikaze/docidset/impl/ImmutableDocSet.java
@@ -13,7 +13,7 @@ public abstract class ImmutableDocSet extends DocSet
   private static final long serialVersionUID = 1L;
   
   private int size = -1;
-  private Logger log = Logger.getLogger(ImmutableDocSet.class.getName());
+  private static final Logger log = Logger.getLogger(ImmutableDocSet.class.getName());
   
   @Override
   public void addDoc(int docid)


### PR DESCRIPTION
... initializing taking 10% of search time when profiling uscp-search.
